### PR TITLE
Improve tunnel error handling

### DIFF
--- a/ios/tunnel/tunnel.go
+++ b/ios/tunnel/tunnel.go
@@ -34,6 +34,7 @@ type Tunnel struct {
 	UserspaceTUN     bool   `json:"userspaceTun"` // Userspace TUN device is used, connect to the local tcp port at Default
 	UserspaceTUNPort int    `json:"userspaceTunPort"`
 	closer           func() error
+	tunnelExited     *bool
 }
 
 // Close closes the connection to the device and removes the virtual network interface from the host
@@ -139,11 +140,15 @@ func connectToTunnel(ctx context.Context, info tunnelListener, addr string, devi
 	// doing it like this allows us to have a context with a timeout for the tunnel creation, but the tunnel itself
 	tunnelCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 
+	var tunnelExited bool = false
+
 	go func() {
 		err := forwardDataToInterface(tunnelCtx, conn, utunIface)
 		if err != nil {
 			logrus.WithError(err).Error("failed to forward data to tunnel interface")
 		}
+
+		tunnelExited = true
 	}()
 
 	go func() {
@@ -151,6 +156,8 @@ func connectToTunnel(ctx context.Context, info tunnelListener, addr string, devi
 		if err != nil {
 			logrus.WithError(err).Error("failed to forward data to the device")
 		}
+
+		tunnelExited = true
 	}()
 
 	closeFunc := func() error {
@@ -161,10 +168,11 @@ func connectToTunnel(ctx context.Context, info tunnelListener, addr string, devi
 	}
 
 	return Tunnel{
-		Address: tunnelInfo.ServerAddress,
-		RsdPort: int(tunnelInfo.ServerRSDPort),
-		Udid:    device.Properties.SerialNumber,
-		closer:  closeFunc,
+		Address:      tunnelInfo.ServerAddress,
+		RsdPort:      int(tunnelInfo.ServerRSDPort),
+		Udid:         device.Properties.SerialNumber,
+		closer:       closeFunc,
+		tunnelExited: &tunnelExited,
 	}, nil
 }
 

--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -485,7 +485,7 @@ func (m *TunnelManager) removeDisconnectedTunnels(ctx context.Context, localTunn
 			}
 		}
 
-		if !exists {
+		if !exists || (tunnel.tunnelExited != nil && *tunnel.tunnelExited) {
 			// Attempt to stop the tunnel.
 			_ = m.stopTunnel(tunnel)
 

--- a/ios/tunnel/tunnel_lockdown.go
+++ b/ios/tunnel/tunnel_lockdown.go
@@ -39,20 +39,24 @@ func connectToTunnelLockdown(ctx context.Context, device ios.DeviceEntry, connTo
 	// doing it like this allows us to have a context with a timeout for the tunnel creation, but the tunnel itself
 	tunnelCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 
+	var tunnelExited bool = false
+
 	go func() {
 		err := forwardTCPToInterface(tunnelCtx, tunnelInfo.ClientParameters.Mtu, connToDevice, utunIface)
 		if err != nil {
 			logrus.WithError(err).Error("failed to forward data to tunnel interface")
-			cancel()
 		}
+
+		tunnelExited = true
 	}()
 
 	go func() {
 		err := forwardTUNToDevice(tunnelCtx, tunnelInfo.ClientParameters.Mtu, utunIface, connToDevice)
 		if err != nil {
 			logrus.WithError(err).Error("failed to forward data to the device")
-			cancel()
 		}
+
+		tunnelExited = true
 	}()
 
 	closeFunc := func() error {
@@ -60,10 +64,11 @@ func connectToTunnelLockdown(ctx context.Context, device ios.DeviceEntry, connTo
 		return errors.Join(utunIface.Close(), connToDevice.Close())
 	}
 	return Tunnel{
-		Address: tunnelInfo.ServerAddress,
-		RsdPort: int(tunnelInfo.ServerRSDPort),
-		Udid:    device.Properties.SerialNumber,
-		closer:  closeFunc,
+		Address:      tunnelInfo.ServerAddress,
+		RsdPort:      int(tunnelInfo.ServerRSDPort),
+		Udid:         device.Properties.SerialNumber,
+		closer:       closeFunc,
+		tunnelExited: &tunnelExited,
 	}, nil
 }
 
@@ -125,6 +130,5 @@ func forwardTCPToInterface(ctx context.Context, mtu uint64, deviceConn io.Reader
 				return fmt.Errorf("could not flush packet: %w", err)
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
Mark the tunnel as exited when either of the go-routines exit.
Remove exited tunnels when removing disconnected tunnels