### PR TITLE
Tunnel: Add unsupported devices to a list to stop further checks

### DIFF
--- a/ios/tunnel/tunnel_api.go
+++ b/ios/tunnel/tunnel_api.go
@@ -219,6 +219,7 @@ type TunnelManager struct {
 	pm                   PairRecordManager
 	mux                  sync.Mutex
 	tunnels              map[string]Tunnel
+	unsupportedDevices   map[string]struct{}
 	startTunnelTimeout   time.Duration
 	firstUpdateCompleted bool
 	userspaceTUN         bool
@@ -235,6 +236,7 @@ func NewTunnelManager(pm PairRecordManager, userspaceTUN bool) *TunnelManager {
 		dl:                 deviceList{},
 		pm:                 pm,
 		tunnels:            map[string]Tunnel{},
+		unsupportedDevices: map[string]struct{}{},
 		startTunnelTimeout: 10 * time.Second,
 		userspaceTUN:       userspaceTUN,
 		portOffset:         1,
@@ -272,10 +274,17 @@ func (m *TunnelManager) FirstUpdateCompleted() bool {
 // On device disconnects the tunnel resources get cleaned up
 func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 	m.mux.Lock()
+
 	localTunnels := make(map[string]Tunnel, len(m.tunnels))
 	for key, tunnel := range m.tunnels {
 		localTunnels[key] = tunnel
 	}
+
+	localUnsupportedDevices := make(map[string]struct{}, len(m.unsupportedDevices))
+	for key, udid := range m.unsupportedDevices {
+		localUnsupportedDevices[key] = udid
+	}
+
 	m.mux.Unlock()
 
 	// Get the list of current devices.
@@ -299,6 +308,11 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 			continue
 		}
 
+		// If the device is in the unsupported list, skip it.
+		if _, unsupported := localUnsupportedDevices[udid]; unsupported {
+			continue
+		}
+
 		// Get the device version.
 		version, err := ios.GetProductVersion(d)
 		if err != nil {
@@ -310,6 +324,17 @@ func (m *TunnelManager) UpdateTunnels(ctx context.Context) error {
 		}
 
 		if version.LessThan(semver.MustParse("17.0.0")) {
+			// Check if this device is already in the unsupported list
+			m.mux.Lock()
+			if _, already := m.unsupportedDevices[udid]; already {
+				m.mux.Unlock()
+				continue
+			}
+
+			// Add to unsupported list
+			m.unsupportedDevices[udid] = struct{}{}
+			m.mux.Unlock()
+
 			log.
 				WithField("udid", udid).
 				Tracef("skipping: unsupported iOS version %s", version.String())
@@ -446,8 +471,6 @@ func (m *TunnelManager) createUsbNcmTunnels(ctx context.Context, localTunnels ma
 		})
 	}
 
-	resume_remoted()
-
 	// Create go-routines to establish each tunnel
 	var wg sync.WaitGroup
 	for _, deviceAddress := range deviceAddrList {
@@ -473,6 +496,8 @@ func (m *TunnelManager) createUsbNcmTunnels(ctx context.Context, localTunnels ma
 		}(deviceAddress.Device, deviceAddress.Address)
 	}
 	wg.Wait()
+
+	resume_remoted()
 }
 
 func (m *TunnelManager) removeDisconnectedTunnels(ctx context.Context, localTunnels map[string]Tunnel, devices ios.DeviceList) {


### PR DESCRIPTION
iOS 16 devices respond to the mdns service discovery requests. These devices are now added to a list to ensure we stop attempting to connect to them.

During the establishment of tunnels for iOS 17.0 -> 17.3.1 devices the remoted service on MacOS is suspended. The resumption of this service has been moved to after the NCM tunnels have been created. This avoids an issue where remoted attempts to connect to the RSD service at the same time as go-ios causing resets.